### PR TITLE
fix #20 - add required argument for ElasticSearchWorker to fix compatibil…

### DIFF
--- a/src/CoreShop2VueStorefrontBundle/Resources/config/services.yml
+++ b/src/CoreShop2VueStorefrontBundle/Resources/config/services.yml
@@ -76,6 +76,7 @@ services:
             - '@coreshop.registry.index.interpreter'
             - '@coreshop.index.filter_group_helper'
             - '@coreshop.index.condition.renderer'
+            - '@coreshop.index.order.renderer'
         shared: false
         calls:
             - { method: setLogger, arguments: ['@logger'] }

--- a/src/CoreShop2VueStorefrontBundle/Worker/ElasticSearchWorker.php
+++ b/src/CoreShop2VueStorefrontBundle/Worker/ElasticSearchWorker.php
@@ -8,9 +8,11 @@ use CoreShop\Component\Index\Condition\ConditionRendererInterface;
 use CoreShop\Component\Index\Model\IndexableInterface;
 use CoreShop\Component\Index\Model\IndexColumnInterface;
 use CoreShop\Component\Index\Model\IndexInterface;
+use CoreShop\Component\Index\Order\OrderRendererInterface;
 use CoreShop\Component\Index\Worker\FilterGroupHelperInterface;
 use CoreShop\Component\Registry\ServiceRegistryInterface;
 use CoreShop2VueStorefrontBundle\Bridge\Attribute\AttributeIdGenerator;
+
 use CoreShop2VueStorefrontBundle\Bridge\DocumentMapper\DocumentAttributeMapper;
 use ONGR\ElasticsearchBundle\Service\Manager;
 use Pimcore\Model\DataObject\ClassDefinition;
@@ -41,6 +43,7 @@ class ElasticSearchWorker extends AbstractWorker
         ServiceRegistryInterface $interpreterServiceRegistry,
         FilterGroupHelperInterface $filterGroupHelper,
         ConditionRendererInterface $conditionRenderer,
+        OrderRendererInterface $orderRenderer,
         DocumentAttributeMapper $documentAttributeBuilder,
         Manager $manager,
         AttributeIdGenerator $attributeIdGenerator
@@ -50,7 +53,8 @@ class ElasticSearchWorker extends AbstractWorker
             $getterServiceRegistry,
             $interpreterServiceRegistry,
             $filterGroupHelper,
-            $conditionRenderer
+            $conditionRenderer,
+            $orderRenderer
         );
 
         $this->documentAttributeBuilder = $documentAttributeBuilder;


### PR DESCRIPTION
This PR fixes https://github.com/DivanteLtd/coreshop-vsbridge/issues/20

Since Coreshop 2.0.4 added the ability to customize the OrderRenderer - there was an argument missing for the ElasticSearchWorker