### PR TITLE
fix: currently the bundle doesn't support ES6 / ES7 typeless indices

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "gesdinet/jwt-refresh-token-bundle": "^0.5.3",
     "gfreeau/get-jwt-bundle": "^2.0",
     "ongr/elasticsearch-bundle": "^5.2",
+    "ongr/elasticsearch-dsl": "^6.0",
     "lexik/jwt-authentication-bundle": "^2.5",
     "nelmio/cors-bundle": "^1.5",
     "pimcore/pimcore": "^5.8 | ^6.0",


### PR DESCRIPTION
This is required because the most recent DSL version (v7) causes this error on ES5 (which is the only one supported ATM):

```
  {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"requ  
  est [/vue_storefront_catalog] contains unrecognized parameter: [include_typ  
  e_name]"}],"type":"illegal_argument_exception","reason":"request [/vue_stor  
  efront_catalog] contains unrecognized parameter: [include_type_name]"},"sta  
  tus":400}  
```