### PR TITLE
fix: enumerate all parent categories in categoryIds too

### DIFF
--- a/src/CoreShop2VueStorefrontBundle/Bridge/DocumentMapper/DocumentConfigurableProductMapper.php
+++ b/src/CoreShop2VueStorefrontBundle/Bridge/DocumentMapper/DocumentConfigurableProductMapper.php
@@ -5,6 +5,7 @@ namespace CoreShop2VueStorefrontBundle\Bridge\DocumentMapper;
 use Cocur\Slugify\SlugifyInterface;
 use CoreShop\Component\Core\Model\ProductInterface;
 use CoreShop\Component\Core\Repository\ProductRepositoryInterface;
+use CoreShop2VueStorefrontBundle\Bridge\Helper\DocumentHelper;
 use CoreShop2VueStorefrontBundle\Bridge\Helper\PriceHelper;
 use CoreShop2VueStorefrontBundle\Document\Attribute;
 use CoreShop2VueStorefrontBundle\Document\ConfigurableChildren;
@@ -38,9 +39,10 @@ class DocumentConfigurableProductMapper extends DocumentProductMapper implements
         ProductRepositoryInterface $productRepository,
         AttributeRepository $attributeRepository,
         DocumentFactory $documentFactory,
+        DocumentHelper $documentHelper,
         PriceHelper $priceHelper
     ) {
-        parent::__construct($slugify, $productRepository, $priceHelper, $documentFactory);
+        parent::__construct($slugify, $productRepository, $priceHelper, $documentFactory, $documentHelper);
         $this->attributeRepository = $attributeRepository;
     }
 

--- a/src/CoreShop2VueStorefrontBundle/Bridge/Helper/DocumentHelper.php
+++ b/src/CoreShop2VueStorefrontBundle/Bridge/Helper/DocumentHelper.php
@@ -28,18 +28,24 @@ class DocumentHelper
         }, $childCategories));
     }
 
+    public function buildParents(CategoryInterface $current): array
+    {
+        $parents = [];
+        do {
+            $parents[] = $current;
+            $current = $current->getParentCategory();
+        } while ($current !== null);
+
+        return array_reverse($parents);
+    }
+
     public function buildPath(CategoryInterface $category): string
     {
-        $chunks = [
-            $category->getId()
-        ];
-        while ($category->getParentCategory() !== null) {
-            $chunks[] = $category->getId();
+        $chunks = array_map(function (CategoryInterface $category): string {
+            return $category->getId();
+        }, $this->buildParents($category));
 
-            $category = $category->getParent();
-        }
-
-        return sprintf("%s/%s", self::CATEGORY_DEFAULT_PATH, implode("/", array_reverse($chunks)));
+        return sprintf("%s/%s", self::CATEGORY_DEFAULT_PATH, implode("/", $chunks));
     }
 
     public function countSeparator(string $haystack, string $needle): int
@@ -49,17 +55,10 @@ class DocumentHelper
 
     public function buildUrlPath(CategoryInterface $category): string
     {
-        $chunks = [
-            $this->slugify->slugify($category->getName())
-        ];
-        while ($category->getParentCategory() !== null) {
-            $category = $category->getParentCategory();
+        $chunks = array_map(function (CategoryInterface $category): string {
+            return $this->slugify->slugify($category->getName());
+        }, $this->buildParents($category));
 
-            if ($category !== null) {
-                $chunks[] = $this->slugify->slugify($category->getName());
-            }
-        }
-
-        return implode('/', array_reverse($chunks));
+        return implode('/', $chunks);
     }
 }


### PR DESCRIPTION
This will enumerate products in all the categories they were assigned to,
but also all their parent categories, making parent categories built out
of their child categories' products.