### PR TITLE
feature: allow repositories to be language aware

### DIFF
--- a/src/CoreShop2VueStorefrontBundle/Bridge/ElasticsearchImporter.php
+++ b/src/CoreShop2VueStorefrontBundle/Bridge/ElasticsearchImporter.php
@@ -7,6 +7,7 @@ namespace CoreShop2VueStorefrontBundle\Bridge;
 use CoreShop\Component\Pimcore\BatchProcessing\BatchListing;
 use CoreShop\Component\Resource\Repository\PimcoreRepositoryInterface;
 use CoreShop\Component\Store\Model\StoreInterface;
+use CoreShop2VueStorefrontBundle\Repository\LanguageAwareRepositoryInterface;
 use CoreShop2VueStorefrontBundle\Repository\StoreAwareRepositoryInterface;
 use Pimcore\Model\Listing\AbstractListing;
 
@@ -58,6 +59,9 @@ class ElasticsearchImporter implements ImporterInterface
 
             if ($this->repository instanceof StoreAwareRepositoryInterface && $this->concreteStore instanceof StoreInterface) {
                 $this->repository->addStoreCondition($this->list, $this->concreteStore);
+            }
+            if($this->repository instanceof LanguageAwareRepositoryInterface && $this->language) {
+                $this->repository->addLanguageCondition($this->list, $this->language);
             }
         }
 

--- a/src/CoreShop2VueStorefrontBundle/Repository/LanguageAwareRepositoryInterface.php
+++ b/src/CoreShop2VueStorefrontBundle/Repository/LanguageAwareRepositoryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+
+namespace CoreShop2VueStorefrontBundle\Repository;
+
+use CoreShop\Component\Resource\Repository\PimcoreRepositoryInterface;
+use Pimcore\Model\Listing\AbstractListing;
+
+interface LanguageAwareRepositoryInterface extends PimcoreRepositoryInterface
+{
+
+    public function addLanguageCondition(AbstractListing $listing, string $language);
+
+}


### PR DESCRIPTION
This PR allows repositories to add language specific conditions by implementing the `LanguageAwareRepositoryInterface` - this feature is especially useful for `Documents` (`cms_page`).