### PR TITLE
[BC break] feature: Coreshop store support

### DIFF
--- a/src/CoreShop2VueStorefrontBundle/Bridge/DocumentMapper/DocumentProductMapper.php
+++ b/src/CoreShop2VueStorefrontBundle/Bridge/DocumentMapper/DocumentProductMapper.php
@@ -4,10 +4,12 @@ namespace CoreShop2VueStorefrontBundle\Bridge\DocumentMapper;
 
 use Cocur\Slugify\SlugifyInterface;
 use CoreShop\Component\Core\Model\ProductInterface;
+use CoreShop\Component\Core\Model\StoreInterface;
 use CoreShop\Component\Core\Repository\ProductRepositoryInterface;
 use CoreShop2VueStorefrontBundle\Bridge\DocumentMapperInterface;
 use CoreShop2VueStorefrontBundle\Bridge\Helper\DocumentHelper;
 use CoreShop2VueStorefrontBundle\Bridge\Helper\PriceHelper;
+use CoreShop2VueStorefrontBundle\Bridge\StoreAwareDocumentMapperInterface;
 use CoreShop2VueStorefrontBundle\Document\MediaGallery;
 use CoreShop2VueStorefrontBundle\Document\Product;
 use CoreShop2VueStorefrontBundle\Document\ProductCategory;
@@ -16,7 +18,7 @@ use ONGR\ElasticsearchBundle\Service\IndexService;
 use Pimcore\Model\Asset\Image;
 use Pimcore\Model\DataObject\AbstractObject;
 
-class DocumentProductMapper extends AbstractMapper implements DocumentMapperInterface
+class DocumentProductMapper extends AbstractMapper implements StoreAwareDocumentMapperInterface
 {
     /** @var SlugifyInterface */
     protected $slugify;
@@ -58,7 +60,7 @@ class DocumentProductMapper extends AbstractMapper implements DocumentMapperInte
      *
      * @return Product
      */
-    public function mapToDocument(IndexService $service, object $product, ?string $language = null): Product
+    public function mapToDocument(IndexService $service, object $product, ?string $language = null, ?StoreInterface $store = null): Product
     {
         $esProduct = $this->find($service, $product);
 
@@ -66,8 +68,8 @@ class DocumentProductMapper extends AbstractMapper implements DocumentMapperInte
 
         $esProduct->setId($product->getId());
         $esProduct->setAttributeSetId(self::PRODUCT_DEFAULT_ATTRIBUTE_SET_ID);
-        $esProduct->setPrice($this->priceHelper->getItemPrice($product));
-        $esProduct->setFinalPrice($this->priceHelper->getItemPrice($product));
+        $esProduct->setPrice($this->priceHelper->getItemPrice($product, $store));
+        $esProduct->setFinalPrice($this->priceHelper->getItemPrice($product, $store));
         $esProduct->setStatus(self::PRODUCT_DEFAULT_STATUS);
         $esProduct->setVisibility(self::PRODUCT_DEFAULT_VISIBILITY);
         $esProduct->setTypeId(self::PRODUCT_SIMPLE_TYPE);

--- a/src/CoreShop2VueStorefrontBundle/Bridge/ElasticsearchImporter.php
+++ b/src/CoreShop2VueStorefrontBundle/Bridge/ElasticsearchImporter.php
@@ -15,28 +15,26 @@ class ElasticsearchImporter implements ImporterInterface
 {
     private $repository;
     private $list;
-    private $store;
+    private $site;
     private $type;
     private $language;
-    private $currency;
     private $persister;
-    /** @var StoreInterface|null */
-    private $concreteStore;
+    /** @var StoreInterface */
+    private $store;
 
-    public function __construct(RepositoryInterface $repository, EnginePersister $persister, string $store, string $type, string $language, string $currency, ?StoreInterface $concreteStore = null)
+    public function __construct(RepositoryInterface $repository, EnginePersister $persister, string $site, string $type, string $language, StoreInterface $store)
     {
         $this->repository = $repository;
         $this->persister = $persister;
-        $this->store = $store;
+        $this->site = $site;
         $this->type = $type;
         $this->language = $language;
-        $this->currency = $currency;
-        $this->concreteStore = $concreteStore;
+        $this->store = $store;
     }
 
     public function describe(): string
     {
-        return sprintf('%1$s: %2$s (%3$s, %4$s)', $this->store, $this->type, $this->language, $this->currency);
+        return sprintf('%1$s: %2$s (%3$s, %4$s)', $this->site, $this->type, $this->language, $this->store->getCurrency()->getIsoCode());
     }
 
     public function getTarget(): string

--- a/src/CoreShop2VueStorefrontBundle/Bridge/ElasticsearchImporter.php
+++ b/src/CoreShop2VueStorefrontBundle/Bridge/ElasticsearchImporter.php
@@ -16,25 +16,32 @@ class ElasticsearchImporter implements ImporterInterface
     private $repository;
     private $list;
     private $store;
-    private $language;
     private $type;
+    private $language;
+    private $currency;
     private $persister;
     /** @var StoreInterface|null */
     private $concreteStore;
 
-    public function __construct(RepositoryInterface $repository, EnginePersister $persister, string $store, string $language, string $type, ?StoreInterface $concreteStore = null)
+    public function __construct(RepositoryInterface $repository, EnginePersister $persister, string $store, string $type, string $language, string $currency, ?StoreInterface $concreteStore = null)
     {
         $this->repository = $repository;
         $this->persister = $persister;
         $this->store = $store;
-        $this->language = $language;
         $this->type = $type;
+        $this->language = $language;
+        $this->currency = $currency;
         $this->concreteStore = $concreteStore;
     }
 
     public function describe(): string
     {
-        return sprintf('%1$s: %2$s (%3$s)', $this->store, $this->type, $this->language);
+        return sprintf('%1$s: %2$s (%3$s, %4$s)', $this->store, $this->type, $this->language, $this->currency);
+    }
+
+    public function getTarget(): string
+    {
+        return $this->persister->getIndexName();
     }
 
     public function count(): int

--- a/src/CoreShop2VueStorefrontBundle/Bridge/EnginePersister.php
+++ b/src/CoreShop2VueStorefrontBundle/Bridge/EnginePersister.php
@@ -3,6 +3,7 @@
 namespace CoreShop2VueStorefrontBundle\Bridge;
 
 use CoreShop\Component\Core\Model\ProductInterface;
+use CoreShop\Component\Core\Model\StoreInterface;
 use CoreShop2VueStorefrontBundle\Bridge\DocumentMapperFactory;
 use CoreShop2VueStorefrontBundle\Document\Attribute;
 use CoreShop2VueStorefrontBundle\Document\Category;
@@ -19,15 +20,18 @@ class EnginePersister
     private $documentMapperFactory;
     /** @var string|null */
     private $language;
+    /** @var StoreInterface|null */
+    private $store;
 
     /** @var null|bool */
     private $indexExists;
 
-    public function __construct(IndexService $indexService, DocumentMapperFactory $documentMapperFactory, ?string $language = null)
+    public function __construct(IndexService $indexService, DocumentMapperFactory $documentMapperFactory, ?string $language = null, ?StoreInterface $store = null)
     {
         $this->indexService = $indexService;
         $this->documentMapperFactory = $documentMapperFactory;
         $this->language = $language;
+        $this->store = $store;
     }
 
     /**
@@ -44,7 +48,11 @@ class EnginePersister
         }
 
         $documentMapper = $this->documentMapperFactory->factory($object);
-        $document = $documentMapper->mapToDocument($this->indexService, $object, $this->language);
+        if ($documentMapper instanceof StoreAwareDocumentMapperInterface) {
+            $document = $documentMapper->mapToDocument($this->indexService, $object, $this->language, $this->store);
+        } else {
+            $document = $documentMapper->mapToDocument($this->indexService, $object, $this->language);
+        }
         $this->indexService->persist($document);
         $this->indexService->commit();
         $this->indexService->flush();

--- a/src/CoreShop2VueStorefrontBundle/Bridge/EnginePersister.php
+++ b/src/CoreShop2VueStorefrontBundle/Bridge/EnginePersister.php
@@ -49,4 +49,9 @@ class EnginePersister
         $this->indexService->commit();
         $this->indexService->flush();
     }
+
+    public function getIndexName(): string
+    {
+        return $this->indexService->getIndexName();
+    }
 }

--- a/src/CoreShop2VueStorefrontBundle/Bridge/Helper/PriceHelper.php
+++ b/src/CoreShop2VueStorefrontBundle/Bridge/Helper/PriceHelper.php
@@ -3,12 +3,13 @@
 namespace CoreShop2VueStorefrontBundle\Bridge\Helper;
 
 use CoreShop\Component\Core\Model\ProductInterface;
+use CoreShop\Component\Core\Model\StoreInterface;
 
 class PriceHelper
 {
-    public function getItemPrice(ProductInterface $product): int
+    public function getItemPrice(ProductInterface $product, ?StoreInterface $store): int
     {
-        $standardPrice = $product->getStorePrice()[1] ?? 0;
+        $standardPrice = ($store !== null ? $product->getStorePrice($store) : $product->getStorePrice($store)[1]) ?? 0;
         return $standardPrice ? abs($standardPrice / 100) : 0;
     }
 }

--- a/src/CoreShop2VueStorefrontBundle/Bridge/ImporterFactory.php
+++ b/src/CoreShop2VueStorefrontBundle/Bridge/ImporterFactory.php
@@ -26,12 +26,12 @@ class ImporterFactory
     /**
      * @return array<ImporterFactory>
      */
-    public function create(?string $store = null, ?string $type = null, ?string $language = null, ?string $currency = null): array
+    public function create(?string $site = null, ?string $type = null, ?string $language = null, ?string $store = null): array
     {
-        $persisters = $this->persisterFactory->create($store, $type, $language, $currency);
+        $persisters = $this->persisterFactory->create($site, $type, $language, $store);
         $importers = [];
         foreach ($persisters as $config) {
-            $importers[] = new ElasticsearchImporter($config['repository'], $config['persister'], $config['store'], $config['type'], $config['language'], $config['currency'], $config['concreteStore']);
+            $importers[] = new ElasticsearchImporter($config['repository'], $config['persister'], $config['site'], $config['type'], $config['language'], $config['store']);
         }
 
         return $importers;

--- a/src/CoreShop2VueStorefrontBundle/Bridge/ImporterFactory.php
+++ b/src/CoreShop2VueStorefrontBundle/Bridge/ImporterFactory.php
@@ -26,12 +26,12 @@ class ImporterFactory
     /**
      * @return array<ImporterFactory>
      */
-    public function create(?string $store = null, ?string $language = null, ?string $type = null): array
+    public function create(?string $store = null, ?string $type = null, ?string $language = null, ?string $currency = null): array
     {
-        $persisters = $this->persisterFactory->create($store, $language, $type);
+        $persisters = $this->persisterFactory->create($store, $type, $language, $currency);
         $importers = [];
         foreach ($persisters as $config) {
-            $importers[] = new ElasticsearchImporter($config['repository'], $config['persister'], $config['store'], $config['language'], $config['type'], $config['concreteStore']);
+            $importers[] = new ElasticsearchImporter($config['repository'], $config['persister'], $config['store'], $config['type'], $config['language'], $config['currency'], $config['concreteStore']);
         }
 
         return $importers;

--- a/src/CoreShop2VueStorefrontBundle/Bridge/ImporterInterface.php
+++ b/src/CoreShop2VueStorefrontBundle/Bridge/ImporterInterface.php
@@ -8,6 +8,8 @@ interface ImporterInterface
 {
     public function describe(): string;
 
+    public function getTarget(): string;
+
     public function count(): int;
 
     public function import(callable $callback): void;

--- a/src/CoreShop2VueStorefrontBundle/Bridge/StoreAwareDocumentMapperInterface.php
+++ b/src/CoreShop2VueStorefrontBundle/Bridge/StoreAwareDocumentMapperInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace CoreShop2VueStorefrontBundle\Bridge;
+
+use CoreShop\Component\Core\Model\StoreInterface;
+use ONGR\ElasticsearchBundle\Service\IndexService;
+use Pimcore\Model\DataObject\AbstractObject;
+use Pimcore\Model\DataObject\ClassDefinition\Data;
+
+interface StoreAwareDocumentMapperInterface extends DocumentMapperInterface
+{
+    /**
+     * @param AbstractObject|Data $object
+     */
+    public function mapToDocument(IndexService $service, object $object, ?string $language = null, ?StoreInterface $store = null);
+}

--- a/src/CoreShop2VueStorefrontBundle/Command/IndexCommand.php
+++ b/src/CoreShop2VueStorefrontBundle/Command/IndexCommand.php
@@ -6,6 +6,7 @@ use CoreShop\Component\Core\Repository\CategoryRepositoryInterface;
 use CoreShop\Component\Core\Repository\ProductRepositoryInterface;
 use CoreShop\Component\Pimcore\BatchProcessing\BatchListing;
 use CoreShop2VueStorefrontBundle\Bridge\ImporterFactory;
+use CoreShop2VueStorefrontBundle\Bridge\ImporterInterface;
 use Pimcore\Console\AbstractCommand;
 use Pimcore\Model\DataObject\Listing;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
@@ -31,6 +32,7 @@ class IndexCommand extends AbstractCommand
             ->addArgument('store', InputArgument::OPTIONAL, 'Store to index')
             ->addArgument('type', InputArgument::OPTIONAL, 'Object types to index')
             ->addArgument('language', InputArgument::OPTIONAL, 'Language to index')
+            ->addArgument('currency', InputArgument::OPTIONAL, 'Currency to index')
             ->setName('vsbridge:index-objects')
             ->setDescription('Indexing objects of given type in vuestorefront');
     }
@@ -55,12 +57,16 @@ class IndexCommand extends AbstractCommand
         $style->title('Coreshop => Vue Storefront data importer');
 
         $store = $input->getArgument('store');
-        $language = $input->getArgument('language');
         $type = $input->getArgument('type');
+        $language = $input->getArgument('language');
+        $currency = $input->getArgument('currency');
 
-        $importers = $this->importerFactory->create($store, $language, $type);
+        $importers = $this->importerFactory->create($store, $type, $language, $currency);
+
+        /** @var ImporterInterface $importer */
         foreach ($importers as $importer) {
             $style->section(sprintf('Importing: %1$s', $importer->describe()));
+            $style->note(sprintf('Target: %1$s', $importer->getTarget()));
 
             $count = $importer->count();
             if ($count === 0) {

--- a/src/CoreShop2VueStorefrontBundle/Command/IndexCommand.php
+++ b/src/CoreShop2VueStorefrontBundle/Command/IndexCommand.php
@@ -29,10 +29,10 @@ class IndexCommand extends AbstractCommand
     protected function configure()
     {
         $this
-            ->addArgument('store', InputArgument::OPTIONAL, 'Store to index')
+            ->addArgument('site', InputArgument::OPTIONAL, 'Site to index')
             ->addArgument('type', InputArgument::OPTIONAL, 'Object types to index')
             ->addArgument('language', InputArgument::OPTIONAL, 'Language to index')
-            ->addArgument('currency', InputArgument::OPTIONAL, 'Currency to index')
+            ->addArgument('store', InputArgument::OPTIONAL, 'Site store to index')
             ->setName('vsbridge:index-objects')
             ->setDescription('Indexing objects of given type in vuestorefront');
     }
@@ -56,12 +56,12 @@ class IndexCommand extends AbstractCommand
         $style = new SymfonyStyle($input, $output);
         $style->title('Coreshop => Vue Storefront data importer');
 
-        $store = $input->getArgument('store');
+        $site = $input->getArgument('site');
         $type = $input->getArgument('type');
         $language = $input->getArgument('language');
-        $currency = $input->getArgument('currency');
+        $store = $input->getArgument('store');
 
-        $importers = $this->importerFactory->create($store, $type, $language, $currency);
+        $importers = $this->importerFactory->create($site, $type, $language, $store);
 
         /** @var ImporterInterface $importer */
         foreach ($importers as $importer) {

--- a/src/CoreShop2VueStorefrontBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop2VueStorefrontBundle/DependencyInjection/Configuration.php
@@ -13,12 +13,10 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     private $languages;
-    private $currencies;
 
-    public function __construct(array $languages, array $currencies)
+    public function __construct(array $languages)
     {
         $this->languages = $languages;
-        $this->currencies = $currencies;
     }
 
     /**
@@ -56,10 +54,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
-                ->booleanNode('store_aware')
-                    ->defaultFalse()
-                ->end()
-                ->arrayNode('stores')
+                ->arrayNode('sites')
                     ->arrayPrototype()
                         ->children()
                             ->arrayNode('languages')
@@ -68,10 +63,9 @@ class Configuration implements ConfigurationInterface
                                     ->values($this->languages)
                                 ->end()
                             ->end()
-                            ->arrayNode('currencies')
+                            ->arrayNode('stores')
                                 ->beforeNormalization()->castToArray()->end()
-                                ->enumPrototype()
-                                    ->values($this->currencies)
+                                ->prototype('scalar')
                                 ->end()
                             ->end()
                         ->end()

--- a/src/CoreShop2VueStorefrontBundle/DependencyInjection/Configuration.php
+++ b/src/CoreShop2VueStorefrontBundle/DependencyInjection/Configuration.php
@@ -13,10 +13,12 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     private $languages;
+    private $currencies;
 
-    public function __construct(array $languages)
+    public function __construct(array $languages, array $currencies)
     {
         $this->languages = $languages;
+        $this->currencies = $currencies;
     }
 
     /**
@@ -64,6 +66,12 @@ class Configuration implements ConfigurationInterface
                                 ->beforeNormalization()->castToArray()->end()
                                 ->enumPrototype()
                                     ->values($this->languages)
+                                ->end()
+                            ->end()
+                            ->arrayNode('currencies')
+                                ->beforeNormalization()->castToArray()->end()
+                                ->enumPrototype()
+                                    ->values($this->currencies)
                                 ->end()
                             ->end()
                         ->end()

--- a/src/CoreShop2VueStorefrontBundle/DependencyInjection/CoreShop2VueStorefrontExtension.php
+++ b/src/CoreShop2VueStorefrontBundle/DependencyInjection/CoreShop2VueStorefrontExtension.php
@@ -20,8 +20,10 @@ class CoreShop2VueStorefrontExtension extends Extension
     public function load(array $configs, ContainerBuilder $container)
     {
         $languages = explode(',', $container->getParameter('pimcore.config')['general']['valid_languages']);
+        // TODO: actually valid currencies
+        $currencies = ['EUR', 'GBP', 'USD'];
 
-        $configuration = new Configuration($languages);
+        $configuration = new Configuration($languages, $currencies);
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('core_shop2_vue_storefront.elasticsearch_config', $config['elasticsearch']);

--- a/src/CoreShop2VueStorefrontBundle/DependencyInjection/CoreShop2VueStorefrontExtension.php
+++ b/src/CoreShop2VueStorefrontBundle/DependencyInjection/CoreShop2VueStorefrontExtension.php
@@ -20,14 +20,12 @@ class CoreShop2VueStorefrontExtension extends Extension
     public function load(array $configs, ContainerBuilder $container)
     {
         $languages = explode(',', $container->getParameter('pimcore.config')['general']['valid_languages']);
-        // TODO: actually valid currencies
-        $currencies = ['EUR', 'GBP', 'USD'];
 
-        $configuration = new Configuration($languages, $currencies);
+        $configuration = new Configuration($languages);
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('core_shop2_vue_storefront.elasticsearch_config', $config['elasticsearch']);
-        $container->setParameter('core_shop2_vue_storefront.stores', $config['stores']);
+        $container->setParameter('core_shop2_vue_storefront.sites', $config['sites']);
         $container->setParameter('core_shop2_vue_storefront.repositories', array_combine(array_keys($config['repositories']), array_column($config['repositories'], 'id')));
         $container->setParameter('core_shop2_vue_storefront.store_aware', $config['store_aware']);
 

--- a/src/CoreShop2VueStorefrontBundle/Resources/config/services.yml
+++ b/src/CoreShop2VueStorefrontBundle/Resources/config/services.yml
@@ -85,9 +85,8 @@ services:
     CoreShop2VueStorefrontBundle\Bridge\PersisterFactory:
         arguments:
             $elasticsearchConfig: '%core_shop2_vue_storefront.elasticsearch_config%'
-            $stores: '%core_shop2_vue_storefront.stores%'
+            $sites: '%core_shop2_vue_storefront.sites%'
             $storeRepository: '@coreshop.repository.store'
-            $storeAware: '%core_shop2_vue_storefront.store_aware%'
 
     CoreShop2VueStorefrontBundle\Command\IndexCommand:
         tags: ['console.command']


### PR DESCRIPTION
This PR changes the configuration for the bridge to better align with Coreshop names for concepts:
- removes `store_aware` config done in #50, now it's store-aware by default (**BC break**)
- `stores` are renamed to `sites` (**BC break**)
- `stores` added inside newly formed `sites`, pointing to Coreshop stores (currently via name)
- a new interface, `StoreAwareDocumentMapperInterface`, allowing the mapper to declare it want the current store when normalizing
- `DocumentProductMapper` migrated to this interface, it accepts the store and fetches the store-specific price

Config looks like this:
```yaml
core_shop2_vue_storefront:
    sites:
        example.nl:
            stores:
                - example.nl # store name, must be the same as Coreshop store name
            languages:
                - nl
        example.co.uk:
            stores:
                - example.co.uk
            languages:
                - en
        example.com:
            stores:
                - example.com EUR
                - example.com USD
            languages:
                - en
        example.de:
            stores:
                - example.de
            languages:
                - de
        example.es:
            stores:
                - example.es
            languages:
                - es
        example.fr:
            stores:
                - example.fr
            languages:
                - fr
```
