### PR TITLE
feat: updated since index param for incremental indexing

### DIFF
--- a/src/CoreShop2VueStorefrontBundle/Bridge/ElasticsearchImporter.php
+++ b/src/CoreShop2VueStorefrontBundle/Bridge/ElasticsearchImporter.php
@@ -21,8 +21,10 @@ class ElasticsearchImporter implements ImporterInterface
     private $persister;
     /** @var StoreInterface */
     private $store;
+    /** @var null|\DateTimeInterface */
+    private $since;
 
-    public function __construct(RepositoryInterface $repository, EnginePersister $persister, string $site, string $type, string $language, StoreInterface $store)
+    public function __construct(RepositoryInterface $repository, EnginePersister $persister, string $site, string $type, string $language, StoreInterface $store, ?\DateTimeInterface $since = null)
     {
         $this->repository = $repository;
         $this->persister = $persister;
@@ -30,6 +32,7 @@ class ElasticsearchImporter implements ImporterInterface
         $this->type = $type;
         $this->language = $language;
         $this->store = $store;
+        $this->since = $since;
     }
 
     public function describe(): string
@@ -79,7 +82,12 @@ class ElasticsearchImporter implements ImporterInterface
                 if ($this->repository instanceof StoreAwareRepositoryInterface && $this->concreteStore instanceof StoreInterface) {
                     $this->repository->addStoreCondition($this->list, $this->concreteStore);
                 }
+
+                if ($this->since !== null) {
+                    $this->list->addConditionParam('o_modificationDate >= ?', $this->since->getTimestamp());
+                }
             } else {
+                // TODO: how to do since here?
                 $this->list = $this->repository->findAll();
             }
         }

--- a/src/CoreShop2VueStorefrontBundle/Bridge/ImporterFactory.php
+++ b/src/CoreShop2VueStorefrontBundle/Bridge/ImporterFactory.php
@@ -26,12 +26,12 @@ class ImporterFactory
     /**
      * @return array<ImporterFactory>
      */
-    public function create(?string $site = null, ?string $type = null, ?string $language = null, ?string $store = null): array
+    public function create(?string $site = null, ?string $type = null, ?string $language = null, ?string $store = null, ?\DateTimeInterface $since = null): array
     {
         $persisters = $this->persisterFactory->create($site, $type, $language, $store);
         $importers = [];
         foreach ($persisters as $config) {
-            $importers[] = new ElasticsearchImporter($config['repository'], $config['persister'], $config['site'], $config['type'], $config['language'], $config['store']);
+            $importers[] = new ElasticsearchImporter($config['repository'], $config['persister'], $config['site'], $config['type'], $config['language'], $config['store'], $since);
         }
 
         return $importers;


### PR DESCRIPTION
This PR adds an `--updated-since` option to the index command, allowing for [datetime expressions compatible with `strtotime`](https://www.php.net/manual/en/datetime.formats.php). This allows us to run index incrementally, for example every day for the last day.

Example usage:

```
bin/console vsbridge:index --updated-since=-2day # must use the long form since - in the value doesn't pass Symfony console options parsing
bin/console vsbridge:index -s yesterday
bin/console vsbridge:index -s "last week"  # must quote to make it a single argument
bin/console vsbridge:index -s 2021-01-01
```

etc.