### PR TITLE
feature: recreate indexes by swapping them under a common alias

### DIFF
--- a/src/CoreShop2VueStorefrontBundle/Bridge/EnginePersister.php
+++ b/src/CoreShop2VueStorefrontBundle/Bridge/EnginePersister.php
@@ -14,7 +14,7 @@ use ONGR\ElasticsearchBundle\Service\Manager;
 
 class EnginePersister
 {
-    /** @var Manager */
+    /** @var IndexService */
     private $indexService;
     /** @var DocumentMapperFactory */
     private $documentMapperFactory;

--- a/src/CoreShop2VueStorefrontBundle/Bridge/ImporterFactory.php
+++ b/src/CoreShop2VueStorefrontBundle/Bridge/ImporterFactory.php
@@ -26,9 +26,9 @@ class ImporterFactory
     /**
      * @return array<ImporterFactory>
      */
-    public function create(?string $site = null, ?string $type = null, ?string $language = null, ?string $store = null, ?\DateTimeInterface $since = null): array
+    public function create(?string $site = null, ?string $type = null, ?string $language = null, ?string $store = null, ?\DateTimeInterface $since = null, ?string $runTimestamp = null): array
     {
-        $persisters = $this->persisterFactory->create($site, $type, $language, $store);
+        $persisters = $this->persisterFactory->create($site, $type, $language, $store, $runTimestamp);
         $importers = [];
         foreach ($persisters as $config) {
             $importers[] = new ElasticsearchImporter($config['repository'], $config['persister'], $config['site'], $config['type'], $config['language'], $config['store'], $since);

--- a/src/CoreShop2VueStorefrontBundle/Bridge/SwappingIndexService.php
+++ b/src/CoreShop2VueStorefrontBundle/Bridge/SwappingIndexService.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CoreShop2VueStorefrontBundle\Bridge;
+
+use ONGR\ElasticsearchBundle\Service\IndexService;
+
+class SwappingIndexService extends IndexService
+{
+    private $runTimestamp;
+    /**
+     * @var IndexService
+     */
+    private $baseIndexService;
+
+    public function __construct(IndexService $baseIndexService, string $runTimestamp)
+    {
+        $this->baseIndexService = $baseIndexService;
+        $this->runTimestamp = $runTimestamp;
+    }
+
+    /**
+     * Flushes ES and adds extra steps needed for swapping (assign alias to new index, remove from old indices, drop old indices)
+     *
+     * @param array $params
+     * @return array
+     */
+    public function flush(array $params = []): array
+    {
+        $return = $this->baseIndexService->flush($params);
+
+        $indicesClient = $this->baseIndexService->getClient()->indices();
+        $settings = $this->baseIndexService->indexSettings;
+
+        $oldIndices = null;
+        // if alias doesn't exist, the previous index will have a clashing name with alias we're creating so we have to drop it
+        if(!$indicesClient->existsAlias(['name' => $settings->getAlias()])) {
+            $this->baseIndexService->dropIndex();
+        }
+        else {
+            //get index names associated with alias
+            $oldIndices = implode(',', array_keys($indicesClient->getAlias(['name' => $settings->getAlias()])));
+            //delete alias from old indices
+            $indicesClient->deleteAlias([
+                "index" => $oldIndices,
+                "name" => $settings->getAlias()
+            ]);
+        }
+        //assign alias to new index
+        $indicesClient->putAlias([
+            "index" => $settings->getIndexName(),
+            "name" => $settings->getAlias()
+        ]);
+
+        if($oldIndices) {
+            //drop old indices
+            $indicesClient->delete([
+                "index" => $oldIndices
+            ]);
+        }
+
+        return $return;
+    }
+
+    public function getBaseIndexService(): IndexService
+    {
+        return $this->baseIndexService;
+    }
+
+    public function __call($method, $args)
+    {
+        if (!method_exists($this, $method) && method_exists($this->baseIndexService, $method)) {
+            return $this->baseIndexService->$method($args);
+        }
+    }
+}

--- a/src/CoreShop2VueStorefrontBundle/Command/IndexCommand.php
+++ b/src/CoreShop2VueStorefrontBundle/Command/IndexCommand.php
@@ -35,6 +35,7 @@ class IndexCommand extends AbstractCommand
             ->addArgument('language', InputArgument::OPTIONAL, 'Language to index')
             ->addArgument('store', InputArgument::OPTIONAL, 'Site store to index')
             ->addOption('updated-since', 's', InputOption::VALUE_OPTIONAL, 'Fetch objects updated in the relative timeframe ("5minute", "2hour", "1day", "yesterday" etc)')
+            ->addOption('swap', null, InputOption::VALUE_OPTIONAL, 'Do a full reingest by swapping indices', false)
             ->setName('vsbridge:index-objects')
             ->setDescription('Indexing objects of given type in vuestorefront');
     }
@@ -63,6 +64,7 @@ class IndexCommand extends AbstractCommand
         $language = $input->getArgument('language');
         $store = $input->getArgument('store');
 
+        $runTimestamp = date('YmdHis');
         $sinceDatetime = null;
         if (null !== $since = $input->getOption('updated-since')) {
             $sinceDatetime = new \Datetime();
@@ -78,7 +80,7 @@ class IndexCommand extends AbstractCommand
             $style->warning(sprintf('Indexing only updated since: %1$s', $sinceDatetime->format('c')));
         }
 
-        $importers = $this->importerFactory->create($site, $type, $language, $store, $sinceDatetime);
+        $importers = $this->importerFactory->create($site, $type, $language, $store, $sinceDatetime, $input->getOption('swap') ? $runTimestamp : null);
 
         /** @var ImporterInterface $importer */
         foreach ($importers as $importer) {


### PR DESCRIPTION
*Note: This is currently a draft*

Problem:
When working with data, some objects will be intentionally deleted. If we want a fresh instance of the index without stale/deleted data, we'd need to recreate it. When recreating it the only available way right now, we'd delete the index and then wait for it to be recreated again. This approach harms overall performance since the site is technically down or will have partial data until the indexing finishes.

Solution:
Use index name as an alias instead and create indices with a timestamp of the indexing time attached. While the new index is being created, the old index will still keep the website operational. Once the new index is ready, delete the old index. This ensures that even though we might have stale data for a little while longer, we at least will have it.